### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
 include LICENSE README.md
 
+recursive-include tasks *
+recursive-include webruntime/tests *
+
 global-exclude .git*
 global-exclude *.pyo
 global-exclude *.pyc


### PR DESCRIPTION
This lets downstream run the unit tests. This is particularly important for Linux rpm packagers.