### PR TITLE
Fix webruntime for modern Firefox versions.

### DIFF
--- a/webruntime/_firefox.py
+++ b/webruntime/_firefox.py
@@ -43,7 +43,7 @@ MinVersion=1.8
 MaxVersion=200.*
 """
 
-MAIN_XUL = """
+MAIN_XHTML = """
 <?xml version="1.0"?>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 
@@ -75,10 +75,10 @@ MAIN_JS = """
 
 PREFS_JS = """
 // This tells xulrunner what xul file to use
-pref("toolkit.defaultChromeURI", "chrome://{name}/content/main.xul");
+pref("toolkit.defaultChromeURI", "chrome://{name}/content/main.xhtml");
 
 // This line is needed to let window.open work
-pref("browser.chromeURL", "chrome://{name}/content/main.xul");
+pref("browser.chromeURL", "chrome://{name}/content/main.xhtml");
 
 // Set features - setting width, height, maximized, etc. here
 pref("toolkit.defaultChromeFeatures", "{windowfeatures}");
@@ -319,7 +319,7 @@ class FirefoxRuntime(DesktopRuntime):
         manifest_link = 'manifest chrome/chrome.manifest'
         manifest = 'content {name} content/'.format(**D)
         application_ini = APPLICATION_INI.format(**D)
-        main_xul = MAIN_XUL.format(**D)
+        main_xhtml = MAIN_XHTML.format(**D)
         main_js = MAIN_JS  # No format (also problematic due to braces)
         prefs_js = PREFS_JS.format(**D)
 
@@ -341,7 +341,7 @@ class FirefoxRuntime(DesktopRuntime):
                             ('application.ini', application_ini),
                             ('defaults/preferences/prefs.js', prefs_js),
                             ('chrome/content/main.js', main_js),
-                            ('chrome/content/main.xul', main_xul),
+                            ('chrome/content/main.xhtml', main_xhtml),
                             ]:
             with open(op.join(path, fname), 'wb') as f:
                 f.write(text.encode())

--- a/webruntime/_firefox.py
+++ b/webruntime/_firefox.py
@@ -62,6 +62,8 @@ MAIN_XHTML = """
     <browser src="{url}"
              id="content"
              type="content"
+             remote="true"
+             remoteType="web"
              flex="1"
              disablehistory="true" />
 </window>


### PR DESCRIPTION
See each individual commit for details.

FWIW, newer versions of Firefox have the [site-specific browser](https://www.maketecheasier.com/enable-site-specific-browser-firefox/) feature, which will be a better fit and much easier to maintain for you, without having to rely on Firefox internals (this is partially Firefox's fault for not having proper embedding APIs!). But I think there's still work ongoing on that, so I haven't made use of it for now.

Instead, do a minor tweak to the existing setup that makes it work in more modern Firefox versions.