### PR TITLE
Saving icons with name 'default.ico'

### DIFF
--- a/webruntime/_firefox.py
+++ b/webruntime/_firefox.py
@@ -351,6 +351,9 @@ class FirefoxRuntime(DesktopRuntime):
         icon_name = op.join(path, 'chrome/icons/default/' + D['windowid'])
         self._icon.write(icon_name + '.ico')
         self._icon.write(icon_name + '.png')
+        icon_name = op.join(path, 'chrome/icons/default/default')
+        self._icon.write(icon_name + '.ico')
+        self._icon.write(icon_name + '.png')
     
     def _copy_xul_runtime(self, dir1, dir2):
         """ Copy the firefox/xulrunner runtime to a new folder, in which


### PR DESCRIPTION
Closes #21 

The previous filenames do not work in my environment, maybe a rule of XUL runner changed. I create copies instead of replacing the previous filenames for compatibility.