### PR TITLE
Added leniency to the code

### DIFF
--- a/webruntime/_common.py
+++ b/webruntime/_common.py
@@ -93,9 +93,21 @@ class BaseRuntime:
         atexit.register(self.close)
         
         # Increase chance of closing runtime when Python is forced to stop
-        signal.signal(signal.SIGTERM, self.close)
-        signal.signal(signal.SIGINT, self.close)
-        
+        try:
+            signal.signal(signal.SIGTERM, self.close)
+        except ValueError as e:  # Cannot use signal.signal outside of main thread
+            if str(e) != 'signal only works in main thread':
+                raise
+            else:
+                pass  # Continue as it will still work on some browser (like Chrome)
+        try:
+            signal.signal(signal.SIGINT, self.close)
+        except ValueError as e:    # Cannot use signal.signal outside of main thread
+            if str(e) != 'signal only works in main thread':
+                raise
+            else:
+                pass  # Continue as it will still work on some browser (like Chrome)
+
         self._exe = None
         self._version = None
         self._proc = None


### PR DESCRIPTION
I`m running flexx into a thread and the signal.signal function can only be used from main thread. I've added code so in that very specific case the error is ignored and everyone is happy. :)